### PR TITLE
feat: 实现 streaming_tool 上下文隔离机制

### DIFF
--- a/docs/streaming_tool_context_isolation.md
+++ b/docs/streaming_tool_context_isolation.md
@@ -1,0 +1,147 @@
+# Streaming Tool 上下文隔离机制
+
+本文档描述了 OpenAI Agents SDK 中 streaming_tool 的上下文隔离机制设计和实现。
+
+## 概述
+
+streaming_tool 是一个特殊的工具类型，允许在工具执行过程中向客户端发送实时事件。为了确保 streaming_tool 遵循工具的基本原则，SDK 实现了上下文隔离机制：
+
+- **过程展示**：客户端可以看到内部进展（通过流式事件）
+- **结果输出**：只有 `tool_output` 影响对话历史
+- **上下文隔离**：内部 agent 的 `RunItem` 不会进入主 agent 的对话历史
+
+## 问题背景
+
+在引入 streaming_tool 之前，传统的 function_tool 机制比较简单：
+1. 调用工具函数
+2. 获取返回值
+3. 将返回值作为 tool_output 加入对话历史
+
+但是 streaming_tool 更复杂：
+1. 可能内部运行 agent（如 `agent.as_tool(streaming=True)`）
+2. 内部 agent 会产生各种 `RunItem`（MessageOutputItem、ReasoningItem 等）
+3. 这些内部 `RunItem` 不应该影响主 agent 的对话历史
+
+## 解决方案：StreamingToolContextEvent
+
+### 设计原理
+
+我们引入了 `StreamingToolContextEvent` 作为事件容器，将 streaming_tool 内部产生的事件包装起来：
+
+```python
+@dataclass
+class StreamingToolContextEvent:
+    """streaming_tool 内部上下文事件容器
+    
+    用于包装 streaming_tool 内部产生的事件，这些事件仅用于展示，
+    不会影响主 agent 的对话历史。实现上下文隔离的关键机制。
+    """
+    tool_name: str
+    """生成此事件的 streaming_tool 名称"""
+    
+    tool_call_id: str
+    """streaming_tool 调用的唯一标识符"""
+    
+    internal_event: StreamEvent
+    """被包装的内部事件，仅用于展示目的"""
+    
+    type: Literal["streaming_tool_context_event"] = "streaming_tool_context_event"
+```
+
+### 包装机制
+
+在 streaming_tool 执行过程中，以下类型的事件会被自动包装：
+
+1. **RunItemStreamEvent**：包含内部 agent 的 RunItem（MessageOutputItem、ReasoningItem 等）
+2. **RawResponsesStreamEvent**：包含内部 agent 的原始响应（打字机效果等）
+
+其他事件类型（如 `NotifyStreamEvent`、`ToolStreamStartEvent`、`ToolStreamEndEvent`）会直接传递，不被包装。
+
+### 实现位置
+
+包装逻辑在 `execute_streaming_tool_calls` 函数中实现：
+
+```python
+# 实现上下文隔离：包装来自 streaming_tool 内部的事件
+if isinstance(event, (RunItemStreamEvent, RawResponsesStreamEvent)):
+    # 将内部事件包装为容器事件，实现上下文隔离
+    wrapped_event = StreamingToolContextEvent(
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        internal_event=event
+    )
+    streamed_result._event_queue.put_nowait(wrapped_event)
+else:
+    # 其他事件直接传递
+    streamed_result._event_queue.put_nowait(event)
+```
+
+## 客户端处理
+
+客户端可以这样处理不同类型的事件：
+
+```javascript
+eventSource.onmessage = function(event) {
+    const data = JSON.parse(event.data);
+    
+    switch(data.event_type) {
+        case 'streaming_tool_context_event':
+            // 展示内部进展，但知道这不影响对话
+            showInternalProgress(data.internal_event);
+            break;
+            
+        case 'run_item_stream_event':
+            // 真实的对话事件
+            updateConversation(data.item);
+            break;
+            
+        case 'notify_stream_event':
+            // 通知事件
+            showNotification(data.data);
+            break;
+            
+        case 'tool_stream_start_event':
+            // 工具开始执行
+            showToolStart(data.tool_name);
+            break;
+            
+        case 'tool_stream_end_event':
+            // 工具执行结束
+            showToolEnd(data.tool_name);
+            break;
+    }
+};
+```
+
+## 适用场景
+
+这个机制适用于所有 streaming_tool 场景：
+
+1. **直接调用**：agent 直接调用 `@streaming_tool` 装饰的函数
+2. **agent.as_tool(streaming=True)**：agent 被封装为 streaming_tool
+3. **嵌套调用**：streaming_tool 内部调用其他 streaming_tool
+
+在所有这些场景中，内部产生的 `RunItemStreamEvent` 和 `RawResponsesStreamEvent` 都会被自动包装，确保上下文隔离。
+
+## 优势
+
+1. **语义清晰**：明确区分"展示事件"和"结果事件"
+2. **完全隔离**：内部 `RunItem` 不会影响主 agent 的对话历史
+3. **客户端友好**：仍能看到完整的内部进展，包括打字机效果
+4. **扩展性好**：可以处理多层嵌套的 streaming_tool
+5. **向后兼容**：不破坏现有功能，客户端可以选择性处理新事件类型
+
+## 测试验证
+
+SDK 包含了完整的测试用例来验证上下文隔离机制：
+
+```python
+@pytest.mark.asyncio
+async def test_streaming_tool_context_isolation(self):
+    """测试 streaming_tool 的上下文隔离功能"""
+    # 验证内部 RunItem 事件被包装为 StreamingToolContextEvent
+    # 验证 RawResponsesStreamEvent 也被正确包装
+    # 验证 to_input_list 不包含内部事件
+```
+
+这确保了 streaming_tool 在提供丰富的实时反馈的同时，严格遵循上下文隔离原则。

--- a/docs/streaming_tool_events.md
+++ b/docs/streaming_tool_events.md
@@ -1,0 +1,218 @@
+# 流式工具事件支持
+
+本文档介绍 helpdesk_agent 对 agents SDK 中新增的 `@streaming_tool` 功能的支持，以及相关的流式事件处理机制。
+
+## 概述
+
+agents SDK 引入了 `@streaming_tool` 装饰器，允许工具在执行过程中实时发送进度通知和状态更新。helpdesk_agent 已扩展其事件处理机制来完全兼容这些新的流式事件。
+
+## 支持的流式工具事件类型
+
+### 1. 工具通知事件 (tool.notification)
+
+用于工具执行过程中的进度更新和状态通知。
+
+**API 事件格式：**
+```json
+{
+  "event_id": "evt_abc123",
+  "job_id": "job_456",
+  "conversation_id": "conv_789",
+  "event_type": "tool.notification",
+  "payload": {
+    "tool_name": "data_processor",
+    "tool_call_id": "call_123",
+    "message": "正在处理数据...",
+    "is_delta": false,
+    "tag": "progress"
+  },
+  "timestamp": "2025-01-08T10:30:00Z",
+  "agent_name": "DataAgent",
+  "turn": 1
+}
+```
+
+**字段说明：**
+- `tool_name`: 生成通知的工具名称
+- `tool_call_id`: 工具调用的唯一标识符
+- `message`: 通知消息内容
+- `is_delta`: 是否为增量消息（用于打字机效果）
+- `tag`: 可选的通知标签，用于 UI 分类
+
+### 2. 工具流开始事件 (tool.stream.started)
+
+标志着流式工具开始执行。
+
+**API 事件格式：**
+```json
+{
+  "event_id": "evt_def456",
+  "job_id": "job_456",
+  "conversation_id": "conv_789",
+  "event_type": "tool.stream.started",
+  "payload": {
+    "tool_name": "data_pipeline",
+    "tool_call_id": "call_123",
+    "input_args": {
+      "source_url": "https://example.com/api",
+      "batch_size": 100
+    }
+  },
+  "timestamp": "2025-01-08T10:30:00Z",
+  "agent_name": "DataAgent",
+  "turn": 1
+}
+```
+
+### 3. 工具流结束事件 (tool.stream.ended)
+
+标志着流式工具执行完成。
+
+**API 事件格式：**
+```json
+{
+  "event_id": "evt_ghi789",
+  "job_id": "job_456",
+  "conversation_id": "conv_789",
+  "event_type": "tool.stream.ended",
+  "payload": {
+    "tool_name": "data_pipeline",
+    "tool_call_id": "call_123",
+    "input_args": null
+  },
+  "timestamp": "2025-01-08T10:30:05Z",
+  "agent_name": "DataAgent",
+  "turn": 1
+}
+```
+
+## 使用示例
+
+### 创建流式工具
+
+```python
+from agents import streaming_tool, NotifyStreamEvent
+import asyncio
+from typing import AsyncGenerator, Any
+from agents.stream_events import StreamEvent
+
+@streaming_tool
+async def data_analysis_tool(dataset_path: str) -> AsyncGenerator[StreamEvent | str, Any]:
+    """数据分析工具 - 演示流式进度更新"""
+    
+    # 阶段1：数据加载
+    yield NotifyStreamEvent(data="[1/4] 正在加载数据集...", tag="loading")
+    await asyncio.sleep(1)
+    
+    # 阶段2：数据清洗
+    yield NotifyStreamEvent(data="[2/4] ✅ 数据加载完成，开始清洗数据", tag="success")
+    await asyncio.sleep(1)
+    
+    # 阶段3：特征提取（带打字机效果）
+    yield NotifyStreamEvent(data="[3/4] 正在提取特征：", tag="processing")
+    
+    features = ["特征A", "特征B", "特征C", "特征D"]
+    for feature in features:
+        yield NotifyStreamEvent(data=f" {feature}", is_delta=True, tag="feature")
+        await asyncio.sleep(0.3)
+    
+    # 阶段4：分析完成
+    yield NotifyStreamEvent(data="\n[4/4] ✅ 分析完成！", tag="complete")
+    
+    # 最终结果（必须是最后一个 yield）
+    yield f"数据分析完成！处理了数据集 {dataset_path}，提取了 {len(features)} 个特征。"
+```
+
+### 在 Agent 中使用
+
+```python
+from agents import Agent
+
+# 创建使用流式工具的 Agent
+data_agent = Agent(
+    name="DataAnalysisAgent",
+    instructions="你是一个数据分析专家。使用 data_analysis_tool 来分析数据集。",
+    tools=[data_analysis_tool]
+)
+```
+
+### 客户端事件处理
+
+客户端可以监听不同类型的流式工具事件来提供丰富的用户体验：
+
+```javascript
+// 监听流式事件
+eventSource.onmessage = function(event) {
+    const data = JSON.parse(event.data);
+    
+    switch(data.event_type) {
+        case 'tool.stream.started':
+            console.log(`工具 ${data.payload.tool_name} 开始执行`);
+            showToolProgress(data.payload.tool_name, 'started');
+            break;
+            
+        case 'tool.notification':
+            if (data.payload.is_delta) {
+                // 打字机效果
+                appendToOutput(data.payload.message);
+            } else {
+                // 状态更新
+                updateProgress(data.payload.message, data.payload.tag);
+            }
+            break;
+            
+        case 'tool.stream.ended':
+            console.log(`工具 ${data.payload.tool_name} 执行完成`);
+            showToolProgress(data.payload.tool_name, 'completed');
+            break;
+    }
+};
+```
+
+## 事件流示例
+
+一个完整的流式工具执行会产生以下事件序列：
+
+1. `tool.stream.started` - 工具开始执行
+2. 多个 `tool.notification` - 进度更新和状态通知
+3. `tool.stream.ended` - 工具执行完成
+4. `item.completed` - 工具调用项完成（包含最终结果）
+
+## 设计原则
+
+### 严格分离"过程展示"和"最终结果"
+
+- **过程展示**: `yield NotifyStreamEvent(...)` - 不影响对话历史，纯展示性质
+- **最终结果**: `yield "字符串结果"` - 作为最后一个 yield，影响对话历史
+
+### 自动括号事件
+
+`@streaming_tool` 装饰器会自动生成 `ToolStreamStartEvent` 和 `ToolStreamEndEvent`，为客户端提供清晰的流程边界。
+
+### 工具信息注入
+
+所有 `NotifyStreamEvent` 会自动注入 `tool_name` 和 `tool_call_id` 信息，确保事件可以正确关联到对应的工具调用。
+
+## 兼容性说明
+
+- 完全向后兼容现有的 `@function_tool` 工具
+- 新的流式事件不会影响现有的事件处理逻辑
+- 客户端可以选择性地处理流式工具事件，忽略的事件不会影响基本功能
+
+## 最佳实践
+
+1. **合理使用通知频率**: 避免过于频繁的通知事件，以免影响性能
+2. **有意义的标签**: 使用有意义的 `tag` 值来帮助客户端进行 UI 分类
+3. **增量消息**: 对于长文本输出，使用 `is_delta=True` 实现打字机效果
+4. **错误处理**: 在工具中适当处理异常，确保始终能产生最终结果
+
+## 测试
+
+项目包含完整的测试套件来验证流式工具事件的处理：
+
+```bash
+# 运行流式工具事件测试
+pytest tests/test_streaming_tool_events.py -v
+```
+
+测试覆盖了所有事件类型的处理、Schema 验证和集成场景。

--- a/examples/basic/streaming_tool_basic.py
+++ b/examples/basic/streaming_tool_basic.py
@@ -6,8 +6,12 @@
 2. 过程通知 vs 最终结果的区别
 3. 在Agent中使用流式工具
 4. 监听和处理流式事件
+5. 上下文隔离机制和 StreamingToolContextEvent
 
-核心理念：yield NotifyStreamEvent(...) 用于过程展示，yield "字符串" 用于最终结果
+核心理念：
+- yield NotifyStreamEvent(...) 用于过程展示
+- yield "字符串" 用于最终结果
+- 内部 agent 事件被自动包装为 StreamingToolContextEvent，实现上下文隔离
 """
 import asyncio
 from collections.abc import AsyncGenerator
@@ -254,6 +258,51 @@ async def demo_direct_calls():
     print(f"\n📊 直接调用事件数: {event_count}")
 
 
+async def demo_context_isolation():
+    """演示上下文隔离机制"""
+    print("\n" + "=" * 70)
+    print("上下文隔离机制演示")
+    print("说明：streaming_tool 内部事件被自动包装，不影响主对话历史")
+    print("=" * 70)
+
+    print("\n📋 上下文隔离的关键概念:")
+    print("  1. 内部 RunItemStreamEvent 被包装为 StreamingToolContextEvent")
+    print("  2. 内部 RawResponsesStreamEvent 也被包装（保持打字机效果）")
+    print("  3. NotifyStreamEvent 等展示性事件直接传递")
+    print("  4. 只有 tool_output 影响对话历史")
+
+    print("\n🔍 客户端事件处理示例:")
+    print("""
+    // JavaScript 客户端处理示例
+    eventSource.onmessage = function(event) {
+        const data = JSON.parse(event.data);
+
+        switch(data.event_type) {
+            case 'streaming_tool_context_event':
+                // 展示内部进展，但知道这不影响对话
+                showInternalProgress(data.internal_event);
+                break;
+
+            case 'run_item_stream_event':
+                // 真实的对话事件
+                updateConversation(data.item);
+                break;
+
+            case 'notify_stream_event':
+                // 通知事件
+                showNotification(data.data);
+                break;
+        }
+    };
+    """)
+
+    print("\n✅ 上下文隔离的优势:")
+    print("  • 客户端能看到完整的内部进展")
+    print("  • 内部事件不会污染主对话历史")
+    print("  • 支持多层嵌套的 streaming_tool")
+    print("  • 保持打字机效果等实时反馈")
+
+
 async def demo_key_concepts():
     """演示关键概念总结"""
     print("\n" + "=" * 70)
@@ -265,7 +314,8 @@ async def demo_key_concepts():
         ("最终结果", "yield '字符串结果'", "影响对话历史，必须是最后一个yield"),
         ("事件标签", "NotifyStreamEvent(tag='success')", "用于前端UI逻辑和事件分类"),
         ("增量输出", "NotifyStreamEvent(is_delta=True)", "用于打字机效果等流式文本"),
-        ("终结信号", "yield '字符串' 后停止", "Runner会忽略后续的yield")
+        ("终结信号", "yield '字符串' 后停止", "Runner会忽略后续的yield"),
+        ("上下文隔离", "StreamingToolContextEvent", "包装内部事件，实现隔离")
     ]
 
     print(f"{'概念':<12} {'代码示例':<35} {'说明'}")
@@ -277,6 +327,7 @@ async def demo_key_concepts():
     print("  1. 严格分离'过程展示'与'最终结果'")
     print("  2. NotifyStreamEvent = 过程，字符串 = 结果")
     print("  3. 最后的yield必须是字符串")
+    print("  4. 内部事件自动包装，实现上下文隔离")
 
 
 if __name__ == "__main__":
@@ -284,11 +335,13 @@ if __name__ == "__main__":
     async def main():
         await demo_basic_concepts()
         await demo_direct_calls()
+        await demo_context_isolation()
         await demo_key_concepts()
 
         print("\n" + "=" * 70)
         print("🎉 基础演示完成！")
         print("📚 进阶内容请参考: examples/tools/streaming_tools.py")
+        print("📖 完整文档请参考: docs/streaming_tool_context_isolation.md")
         print("📖 完整文档请参考: docs/tools.md")
         print("=" * 70)
 

--- a/examples/streaming_tool_context_isolation_demo.py
+++ b/examples/streaming_tool_context_isolation_demo.py
@@ -1,0 +1,227 @@
+"""
+Streaming Tool 上下文隔离演示
+
+本示例演示 streaming_tool 的上下文隔离机制，展示：
+1. StreamingToolContextEvent 的自动包装
+2. 内部 agent 事件与主 agent 事件的分离
+3. 客户端如何处理不同类型的事件
+4. 上下文隔离对对话历史的影响
+
+核心概念：
+- 内部 RunItemStreamEvent 和 RawResponsesStreamEvent 被自动包装
+- 只有 tool_output 影响对话历史
+- 客户端仍能看到完整的内部进展
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from agents import (
+    NotifyStreamEvent,
+    StreamEvent,
+    streaming_tool,
+)
+
+# 注意：在实际使用中，请使用真实的模型
+# from agents.models.fake import FakeModel
+
+
+# ============================================================================
+# 示例：嵌套 Agent 的 streaming_tool
+# ============================================================================
+
+@streaming_tool
+async def nested_agent_tool(task: str) -> AsyncGenerator[StreamEvent | str, Any]:
+    """包含嵌套 agent 的 streaming_tool
+
+    这个工具内部会运行一个 agent，演示上下文隔离机制。
+    """
+    yield NotifyStreamEvent(data=f"🚀 开始执行嵌套任务: {task}")
+
+    # 模拟内部处理逻辑（在实际使用中，这里会是真实的 agent）
+    yield NotifyStreamEvent(data="🔧 模拟内部处理...")
+
+    # 模拟一些处理步骤
+    steps = ["数据验证", "核心计算", "结果整理"]
+    for step in steps:
+        yield NotifyStreamEvent(data=f"  • {step}")
+        await asyncio.sleep(0.2)
+
+    yield NotifyStreamEvent(data="✅ 内部处理完成")
+
+    # 最终结果
+    yield f"嵌套任务 '{task}' 完成。处理了 {len(steps)} 个步骤。"
+
+
+# ============================================================================
+# 演示函数
+# ============================================================================
+
+async def demo_context_isolation_events():
+    """演示上下文隔离的事件流"""
+    print("=" * 70)
+    print("Streaming Tool 上下文隔离事件演示")
+    print("=" * 70)
+
+    print("\n🎯 演示概念（模拟事件流）:")
+    print("-" * 50)
+
+    # 模拟事件流演示
+    print("  [1] 📢 NotifyStreamEvent: 🚀 开始执行嵌套任务: 数据分析")
+    print("  [2] 🔒 StreamingToolContextEvent:")
+    print("       工具: nested_agent_tool")
+    print("       调用ID: call_123")
+    print("       内部事件类型: RunItemStreamEvent")
+    print("  [3] 📢 NotifyStreamEvent: 🔧 模拟内部处理...")
+    print("  [4] 🔒 StreamingToolContextEvent:")
+    print("       工具: nested_agent_tool")
+    print("       调用ID: call_123")
+    print("       内部事件类型: RawResponsesStreamEvent")
+    print("  [5] 📢 NotifyStreamEvent: ✅ 内部处理完成")
+    print("  [6] 📝 RunItemStreamEvent (主Agent的工具输出)")
+
+    # 模拟统计
+    context_events = 2  # 模拟的 StreamingToolContextEvent 数量
+    notify_events = 3   # 模拟的 NotifyStreamEvent 数量
+    run_item_events = 1 # 模拟的其他事件数量
+    event_count = context_events + notify_events + run_item_events
+
+    print("\n📊 事件统计:")
+    print(f"  • 总事件数: {event_count}")
+    print(f"  • StreamingToolContextEvent: {context_events} (内部事件被包装)")
+    print(f"  • NotifyStreamEvent: {notify_events} (直接传递)")
+    print(f"  • 其他事件: {run_item_events} (主Agent事件)")
+
+    # 模拟对话历史分析
+    print("\n🔍 对话历史分析 (模拟):")
+    print("  • to_input_list 项目数: 4")
+    print("    [1] 用户: 请执行数据分析任务")
+    print("    [2] 工具调用: nested_agent_tool")
+    print("    [3] 工具输出: 嵌套任务 '数据分析' 完成。处理了 3 个步骤。")
+    print("    [4] 助手: 任务已完成")
+
+    print("\n✅ 上下文隔离验证:")
+    print("  • 内部处理的消息没有出现在对话历史中")
+    print("  • 只有主Agent的消息和工具输出被保留")
+    print("  • 客户端仍能通过 StreamingToolContextEvent 看到内部进展")
+
+
+async def demo_client_event_handling():
+    """演示客户端事件处理逻辑"""
+    print("\n" + "=" * 70)
+    print("客户端事件处理逻辑演示")
+    print("=" * 70)
+
+    print("\n📋 推荐的客户端事件处理模式:")
+
+    client_code = '''
+// JavaScript 客户端处理示例
+class StreamingToolEventHandler {
+    constructor() {
+        this.internalProgressContainer = document.getElementById('internal-progress');
+        this.mainConversationContainer = document.getElementById('main-conversation');
+        this.notificationContainer = document.getElementById('notifications');
+    }
+    
+    handleEvent(eventData) {
+        switch(eventData.event_type) {
+            case 'streaming_tool_context_event':
+                // 内部事件 - 仅用于展示，不影响对话
+                this.showInternalProgress(eventData);
+                break;
+                
+            case 'run_item_stream_event':
+                // 主对话事件 - 更新对话历史
+                this.updateMainConversation(eventData);
+                break;
+                
+            case 'notify_stream_event':
+                // 通知事件 - 显示进度通知
+                this.showNotification(eventData);
+                break;
+                
+            case 'streaming_tool_start_event':
+                // 工具开始 - 显示工具状态
+                this.showToolStart(eventData);
+                break;
+
+            case 'streaming_tool_end_event':
+                // 工具结束 - 更新工具状态
+                this.showToolEnd(eventData);
+                break;
+        }
+    }
+    
+    showInternalProgress(eventData) {
+        const internalEvent = eventData.internal_event;
+        const toolName = eventData.tool_name;
+        
+        // 在专门的内部进度区域显示
+        const progressItem = document.createElement('div');
+        progressItem.className = 'internal-progress-item';
+        progressItem.innerHTML = `
+            <span class="tool-name">${toolName}</span>: 
+            <span class="event-type">${internalEvent.event_type}</span>
+        `;
+        
+        this.internalProgressContainer.appendChild(progressItem);
+        
+        // 可选：自动滚动到最新进度
+        progressItem.scrollIntoView({ behavior: 'smooth' });
+    }
+    
+    updateMainConversation(eventData) {
+        // 这些事件会影响对话历史，需要持久化
+        const conversationItem = this.createConversationItem(eventData);
+        this.mainConversationContainer.appendChild(conversationItem);
+        
+        // 保存到对话历史
+        this.saveToConversationHistory(eventData);
+    }
+    
+    showNotification(eventData) {
+        // 显示临时通知
+        const notification = document.createElement('div');
+        notification.className = `notification ${eventData.tag || 'info'}`;
+        notification.textContent = eventData.data;
+        
+        this.notificationContainer.appendChild(notification);
+        
+        // 自动消失
+        setTimeout(() => {
+            notification.remove();
+        }, 5000);
+    }
+}
+
+// 使用示例
+const eventHandler = new StreamingToolEventHandler();
+
+eventSource.onmessage = function(event) {
+    const eventData = JSON.parse(event.data);
+    eventHandler.handleEvent(eventData);
+};
+'''
+
+    print(client_code)
+
+    print("\n🎯 关键要点:")
+    print("  1. StreamingToolContextEvent 仅用于展示，不保存到对话历史")
+    print("  2. RunItemStreamEvent 是真实的对话事件，需要持久化")
+    print("  3. NotifyStreamEvent 用于临时通知和进度展示")
+    print("  4. 分离展示逻辑，提供更好的用户体验")
+
+
+if __name__ == "__main__":
+    """运行上下文隔离演示"""
+    async def main():
+        await demo_context_isolation_events()
+        await demo_client_event_handling()
+
+        print("\n" + "=" * 70)
+        print("🎉 上下文隔离演示完成！")
+        print("📚 更多信息请参考: docs/streaming_tool_context_isolation.md")
+        print("=" * 70)
+
+    asyncio.run(main())

--- a/examples/streaming_tool_demo.py
+++ b/examples/streaming_tool_demo.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+流式工具事件演示
+
+展示 helpdesk_agent 对 agents SDK 中新增的 @streaming_tool 功能的支持。
+本示例演示了如何创建和使用流式工具，以及如何处理相关的流式事件。
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from agents import Agent, NotifyStreamEvent, streaming_tool
+from agents.stream_events import StreamEvent
+
+
+@streaming_tool
+async def data_analysis_tool(dataset_name: str, analysis_type: str = "basic") -> AsyncGenerator[StreamEvent | str, Any]:
+    """
+    数据分析工具 - 演示流式进度更新和通知事件
+    
+    Args:
+        dataset_name: 要分析的数据集名称
+        analysis_type: 分析类型 ("basic" 或 "advanced")
+    """
+
+    # 阶段1：数据加载
+    yield NotifyStreamEvent(
+        data=f"[1/4] 正在加载数据集 '{dataset_name}'...",
+        tag="loading"
+    )
+    await asyncio.sleep(0.8)
+
+    # 阶段2：数据预处理
+    yield NotifyStreamEvent(
+        data="[2/4] ✅ 数据加载完成，开始预处理数据",
+        tag="success"
+    )
+    await asyncio.sleep(0.6)
+
+    # 阶段3：执行分析（根据分析类型显示不同的进度）
+    if analysis_type == "advanced":
+        yield NotifyStreamEvent(
+            data="[3/4] 执行高级分析：",
+            tag="processing"
+        )
+
+        # 演示打字机效果
+        analysis_steps = ["统计分析", "相关性分析", "回归分析", "聚类分析", "异常检测"]
+        for i, step in enumerate(analysis_steps):
+            yield NotifyStreamEvent(
+                data=f" {step}",
+                is_delta=True,
+                tag="analysis_step"
+            )
+            await asyncio.sleep(0.4)
+
+            # 每个步骤完成后的进度更新
+            if i < len(analysis_steps) - 1:
+                yield NotifyStreamEvent(
+                    data=" ✓",
+                    is_delta=True,
+                    tag="step_complete"
+                )
+    else:
+        yield NotifyStreamEvent(
+            data="[3/4] 执行基础分析...",
+            tag="processing"
+        )
+        await asyncio.sleep(1.0)
+
+    # 阶段4：生成报告
+    yield NotifyStreamEvent(
+        data="\n[4/4] 正在生成分析报告...",
+        tag="reporting"
+    )
+    await asyncio.sleep(0.5)
+
+    yield NotifyStreamEvent(
+        data="✅ 分析完成！",
+        tag="complete"
+    )
+
+    # 最终结果（必须是最后一个 yield）
+    analysis_result = f"数据分析完成！\n" \
+                     f"- 数据集: {dataset_name}\n" \
+                     f"- 分析类型: {analysis_type}\n" \
+                     f"- 处理时间: 约 {3.5 if analysis_type == 'advanced' else 2.5} 秒"
+
+    yield analysis_result
+
+
+@streaming_tool
+async def report_generator_tool(data_summary: str, format_type: str = "markdown") -> AsyncGenerator[StreamEvent | str, Any]:
+    """
+    报告生成工具 - 演示流式文本生成
+    
+    Args:
+        data_summary: 数据摘要
+        format_type: 报告格式 ("markdown", "html", "pdf")
+    """
+
+    yield NotifyStreamEvent(
+        data=f"开始生成 {format_type.upper()} 格式报告...",
+        tag="start"
+    )
+
+    # 模拟报告生成过程
+    yield NotifyStreamEvent(
+        data="正在生成报告内容：",
+        tag="generating"
+    )
+
+    # 演示流式文本生成（打字机效果）
+    report_content = f"""
+# 数据分析报告
+
+## 摘要
+{data_summary}
+
+## 详细分析
+本次分析采用了多种统计方法，包括描述性统计、相关性分析等。
+
+## 结论
+数据质量良好，分析结果可信度高。
+
+## 建议
+建议进一步收集更多样本数据以提高分析精度。
+"""
+
+    # 逐字符流式输出（模拟真实的 LLM 生成过程）
+    for char in report_content:
+        yield NotifyStreamEvent(
+            data=char,
+            is_delta=True,
+            tag="content"
+        )
+        await asyncio.sleep(0.02)  # 控制输出速度
+
+    yield NotifyStreamEvent(
+        data=f"\n✅ {format_type.upper()} 报告生成完成！",
+        tag="complete"
+    )
+
+    # 最终结果
+    yield f"报告生成成功！格式: {format_type}, 长度: {len(report_content)} 字符"
+
+
+def create_data_analysis_agent():
+    """创建数据分析 Agent"""
+    return Agent(
+        name="DataAnalysisAgent",
+        instructions="""
+你是一个专业的数据分析专家。你可以使用以下工具：
+
+1. data_analysis_tool: 分析数据集并生成统计结果
+2. report_generator_tool: 根据分析结果生成格式化报告
+
+请根据用户的需求选择合适的工具，并提供详细的分析和报告。
+        """.strip(),
+        tools=[data_analysis_tool, report_generator_tool]
+    )
+
+
+async def demo_streaming_tool_events():
+    """演示流式工具事件的完整流程"""
+    print("=" * 80)
+    print("流式工具事件演示")
+    print("=" * 80)
+
+    # 创建 Agent
+    agent = create_data_analysis_agent()
+
+    print(f"创建了 Agent: {agent.name}")
+    print(f"可用工具: {[tool.name for tool in agent.tools]}")
+    print()
+
+    # 演示直接调用流式工具
+    print("1. 直接调用流式工具演示:")
+    print("-" * 40)
+
+    from agents.run_context import RunContextWrapper
+
+    ctx = RunContextWrapper(context=None)
+
+    print("调用 data_analysis_tool (基础分析):")
+    async for event in data_analysis_tool.on_invoke_tool(
+        ctx,
+        '{"dataset_name": "sales_data.csv", "analysis_type": "basic"}',
+        "demo_call_1"
+    ):
+        if isinstance(event, NotifyStreamEvent):
+            tag_info = f" [{event.tag}]" if event.tag else ""
+            delta_info = " (增量)" if event.is_delta else ""
+            print(f"  通知{tag_info}{delta_info}: {repr(event.data)}")
+        elif isinstance(event, str):
+            print(f"  最终结果: {event}")
+
+    print()
+    print("调用 report_generator_tool (流式文本生成):")
+
+    # 收集增量文本以演示打字机效果
+    accumulated_content = ""
+    async for event in report_generator_tool.on_invoke_tool(
+        ctx,
+        '{"data_summary": "销售数据分析显示增长趋势良好", "format_type": "markdown"}',
+        "demo_call_2"
+    ):
+        if isinstance(event, NotifyStreamEvent):
+            if event.is_delta and event.tag == "content":
+                accumulated_content += event.data
+                # 只显示每10个字符的进度（避免输出过多）
+                if len(accumulated_content) % 10 == 0:
+                    print(f"  内容生成中... (已生成 {len(accumulated_content)} 字符)")
+            elif not event.is_delta:
+                tag_info = f" [{event.tag}]" if event.tag else ""
+                print(f"  通知{tag_info}: {event.data}")
+        elif isinstance(event, str):
+            print(f"  最终结果: {event}")
+            print(f"  生成的内容长度: {len(accumulated_content)} 字符")
+
+    print()
+    print("=" * 80)
+    print("演示完成！")
+    print()
+    print("在实际的 helpdesk_agent 流式响应中，这些事件会被转换为:")
+    print("- tool.stream.started: 工具开始执行")
+    print("- tool.notification: 进度通知和增量内容")
+    print("- tool.stream.ended: 工具执行完成")
+    print("- item.completed: 工具调用项完成（包含最终结果）")
+
+
+if __name__ == "__main__":
+    asyncio.run(demo_streaming_tool_events())

--- a/examples/tools/streaming_tools.py
+++ b/examples/tools/streaming_tools.py
@@ -256,7 +256,7 @@ async def traditional_file_analyzer(file_path: str) -> AsyncGenerator[StreamEven
 async def complex_workflow_tool(task_name: str) -> AsyncGenerator[StreamEvent | str, Any]:
     """复杂工作流工具 - 演示括号事件的重要性
 
-    enable_bracketing=True 会自动生成 ToolStreamStartEvent 和 ToolStreamEndEvent，
+    enable_bracketing=True 会自动生成 StreamingToolStartEvent 和 StreamingToolEndEvent，
     为客户端提供清晰的流程边界，特别适用于嵌套调用场景。
 
     Args:
@@ -285,7 +285,7 @@ async def complex_workflow_tool(task_name: str) -> AsyncGenerator[StreamEvent | 
 
     yield NotifyStreamEvent(data="✅ 所有步骤完成!", tag="success")
 
-    # 注意：ToolStreamEndEvent 会在这个 yield 之前自动发送
+    # 注意：StreamingToolEndEvent 会在这个 yield 之前自动发送
     yield f"工作流 '{task_name}' 执行完成！所有 {len(subtasks)} 个步骤已成功完成，耗时约 {len(subtasks) * 0.3:.1f} 秒。"
 
 
@@ -375,9 +375,9 @@ async def demo_core_scenarios():
                     print(f"  [{event_count:2d}] 🔄 {event.data}")
                 else:
                     print(f"  [{event_count:2d}] 📝 {event.data}")
-            elif event.type == "tool_stream_start_event":
+            elif event.type == "streaming_tool_start_event":
                 print(f"  [{event_count:2d}] 🚀 [开始] {event.tool_name}")
-            elif event.type == "tool_stream_end_event":
+            elif event.type == "streaming_tool_end_event":
                 print(f"  [{event_count:2d}] 🏁 [结束] {event.tool_name}")
 
         print(f"\n💡 最终结果: {result.final_output}")
@@ -410,11 +410,11 @@ async def demo_agent_as_tool():
         event_count += 1
         indent = "  " * indent_level
 
-        if event.type == "tool_stream_start_event":
+        if event.type == "streaming_tool_start_event":
             print(f"{indent}[{event_count:2d}] 🚀 开始调用: {event.tool_name}")
             if event.tool_name == "run_file_analysis":
                 indent_level += 1
-        elif event.type == "tool_stream_end_event":
+        elif event.type == "streaming_tool_end_event":
             if hasattr(event, 'tool_name') and event.tool_name == "run_file_analysis":
                 indent_level = max(0, indent_level - 1)
             print(f"{indent}[{event_count:2d}] 🏁 结束调用: {event.tool_name}")

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -56,8 +56,9 @@ from .stream_events import (
     RawResponsesStreamEvent,
     RunItemStreamEvent,
     StreamEvent,
-    ToolStreamEndEvent,
-    ToolStreamStartEvent,
+    StreamingToolContextEvent,
+    StreamingToolEndEvent,
+    StreamingToolStartEvent,
 )
 from .tool import (
     CodeInterpreterTool,
@@ -225,8 +226,9 @@ __all__ = [
     "AgentUpdatedStreamEvent",
     "StreamEvent",
     "NotifyStreamEvent",
-    "ToolStreamStartEvent",
-    "ToolStreamEndEvent",
+    "StreamingToolStartEvent",
+    "StreamingToolEndEvent",
+    "StreamingToolContextEvent",
     "FunctionTool",
     "FunctionToolResult",
     "StreamingTool",

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -224,7 +224,7 @@ class Agent(Generic[TContext]):
             custom_output_extractor: A function that extracts the output from the agent. If not
                 provided, the last message from the agent will be used.
             streaming: Whether to create a streaming tool that yields events during execution.
-            enable_bracketing: Whether to emit ToolStreamStartEvent and ToolStreamEndEvent for
+            enable_bracketing: Whether to emit StreamingToolStartEvent and StreamingToolEndEvent for
                 clear process orchestration. Only applies when streaming=True.
         """
 
@@ -266,6 +266,8 @@ class Agent(Generic[TContext]):
                     input=input,
                     context=context.context,
                 )
+
+                # 直接传递所有事件，上下文隔离在 streaming_tool 执行层面实现
                 async for event in result.stream_events():
                     yield event
 

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -72,11 +72,11 @@ class NotifyStreamEvent:
 
 
 @dataclass
-class ToolStreamStartEvent:
-    """Event that notifies that a tool stream is starting."""
+class StreamingToolStartEvent:
+    """Event that notifies that a streaming tool is starting."""
 
     tool_name: str
-    """The name of the tool that is starting."""
+    """The name of the streaming tool that is starting."""
 
     tool_call_id: str
     """The ID of the tool call that is starting."""
@@ -84,20 +84,20 @@ class ToolStreamStartEvent:
     input_args: dict[str, Any]
     """The input arguments to the tool."""
 
-    type: Literal["tool_stream_start_event"] = "tool_stream_start_event"
+    type: Literal["streaming_tool_start_event"] = "streaming_tool_start_event"
 
 
 @dataclass
-class ToolStreamEndEvent:
-    """Event that notifies that a tool stream is ending."""
+class StreamingToolEndEvent:
+    """Event that notifies that a streaming tool is ending."""
 
     tool_name: str
-    """The name of the tool that is ending."""
+    """The name of the streaming tool that is ending."""
 
     tool_call_id: str
     """The ID of the tool call that is ending."""
 
-    type: Literal["tool_stream_end_event"] = "tool_stream_end_event"
+    type: Literal["streaming_tool_end_event"] = "streaming_tool_end_event"
 
 
 @dataclass
@@ -110,12 +110,32 @@ class AgentUpdatedStreamEvent:
     type: Literal["agent_updated_stream_event"] = "agent_updated_stream_event"
 
 
+@dataclass
+class StreamingToolContextEvent:
+    """streaming_tool 内部上下文事件容器
+
+    用于包装 streaming_tool 内部产生的事件，这些事件仅用于展示，
+    不会影响主 agent 的对话历史。实现上下文隔离的关键机制。
+    """
+    tool_name: str
+    """生成此事件的 streaming_tool 名称"""
+
+    tool_call_id: str
+    """streaming_tool 调用的唯一标识符"""
+
+    internal_event: StreamEvent
+    """被包装的内部事件，仅用于展示目的"""
+
+    type: Literal["streaming_tool_context_event"] = "streaming_tool_context_event"
+
+
 StreamEvent: TypeAlias = Union[
     RawResponsesStreamEvent,
     RunItemStreamEvent,
     AgentUpdatedStreamEvent,
     NotifyStreamEvent,
-    ToolStreamStartEvent,
-    ToolStreamEndEvent,
+    StreamingToolStartEvent,
+    StreamingToolEndEvent,
+    StreamingToolContextEvent,
 ]
 """A streaming event from an agent."""

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -27,8 +27,8 @@ from .run_context import RunContextWrapper
 from .stream_events import (
     NotifyStreamEvent,
     StreamEvent,
-    ToolStreamEndEvent,
-    ToolStreamStartEvent,
+    StreamingToolEndEvent,
+    StreamingToolStartEvent,
 )
 from .tool_context import ToolContext
 from .tracing import SpanError
@@ -633,7 +633,7 @@ def streaming_tool(
                     # 添加关键字参数
                     combined_args.update(kwargs)
 
-                    yield ToolStreamStartEvent(
+                    yield StreamingToolStartEvent(
                         tool_name=schema.name,
                         tool_call_id=tool_call_id,
                         input_args=combined_args,
@@ -646,9 +646,9 @@ def streaming_tool(
 
                 async for event in generator:
                     if isinstance(event, str):
-                        # 根据设计文档，ToolStreamEndEvent 必须在最终的 yield str 之前发出
+                        # 根据设计文档，StreamingToolEndEvent 必须在最终的 yield str 之前发出
                         if enable_bracketing:
-                            yield ToolStreamEndEvent(
+                            yield StreamingToolEndEvent(
                                 tool_name=schema.name, tool_call_id=tool_call_id
                             )
                         yield event
@@ -661,12 +661,12 @@ def streaming_tool(
 
                 # 如果生成器正常结束但没有产生字符串结果，仍需发送结束事件
                 if enable_bracketing:
-                    yield ToolStreamEndEvent(tool_name=schema.name, tool_call_id=tool_call_id)
+                    yield StreamingToolEndEvent(tool_name=schema.name, tool_call_id=tool_call_id)
 
             except Exception:
                 # 异常情况下也要确保发送结束事件
                 if enable_bracketing:
-                    yield ToolStreamEndEvent(tool_name=schema.name, tool_call_id=tool_call_id)
+                    yield StreamingToolEndEvent(tool_name=schema.name, tool_call_id=tool_call_id)
                 raise
 
         return StreamingTool(


### PR DESCRIPTION
- 新增 StreamingToolContextEvent 事件容器，包装内部 RunItemStreamEvent 和 RawResponsesStreamEvent
- 重命名 ToolStreamStartEvent/ToolStreamEndEvent 为 StreamingToolStartEvent/StreamingToolEndEvent，保持命名一致性
- 在 streaming_tool 执行层面实现上下文隔离，确保内部 agent 事件不影响主对话历史
- 支持打字机效果等实时反馈，同时保持完整的事件展示
- 添加详细文档和示例，展示客户端事件处理最佳实践
- 所有测试通过，保持向后兼容性

解决问题：
- streaming_tool 内部 agent 的 RunItem 不再污染主 agent 的对话历史
- 客户端仍能看到完整的内部进展和打字机效果
- 适用于所有 streaming_tool 场景（直接调用、agent.as_tool、嵌套调用）