### PR TITLE
fix: JsonObjectOutputSchema 在 DeepSeek API 中的 response_format 兼容性问题

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -74,7 +74,15 @@ class Converter:
         if not final_output_schema or final_output_schema.is_plain_text():
             return NOT_GIVEN
 
-        # 使用 json_schema 模式
+        # 检查是否是 JsonObjectOutputSchema，如果是则使用 json_object 模式
+        # 这是为了兼容只支持 json_object 格式的 LLM 提供商（如 DeepSeek）
+        from ..json_object_output import JsonObjectOutputSchema
+        if isinstance(final_output_schema, JsonObjectOutputSchema):
+            return {
+                "type": "json_object"
+            }
+
+        # 其他情况使用 json_schema 模式
         return {
             "type": "json_schema",
             "json_schema": {


### PR DESCRIPTION
## 问题描述

修复 `JsonObjectOutputSchema` 在 DeepSeek API 中出现的 `response_format type is unavailable` 错误。

## 根本原因

`openai-agents-python-enhanced` 框架中的 `Converter.convert_response_format()` 方法对所有非纯文本输出模式都使用 `json_schema` 格式，但是 `JsonObjectOutputSchema` 的设计目的是为了兼容只支持 `{'type': 'json_object'}` 格式的 LLM 提供商（如 DeepSeek）。

## 解决方案

在 `src/agents/models/chatcmpl_converter.py` 的 `convert_response_format` 方法中添加对 `JsonObjectOutputSchema` 的特殊处理：

- 检查是否是 `JsonObjectOutputSchema` 实例
- 如果是，则返回 `{'type': 'json_object'}` 格式
- 其他情况继续使用 `json_schema` 格式

## 测试

- ✅ 添加了单元测试验证 `JsonObjectOutputSchema` 返回正确的 `json_object` 格式
- ✅ 添加了回归测试确保 `AgentOutputSchema` 仍然使用 `json_schema` 格式
- ✅ 所有现有测试通过
- ✅ 代码格式检查通过

## 影响范围

- 修复了所有使用 `JsonObjectOutputSchema` 的 Agent 在 DeepSeek API 上的兼容性问题
- 保持了其他输出模式的向后兼容性
- 不影响现有功能

## 验收标准

- [x] `JsonObjectOutputSchema` 在 DeepSeek API 中能正常工作
- [x] 其他输出模式（`AgentOutputSchema`）的功能不受影响
- [x] 新增代码有完整的单元测试覆盖
- [x] 通过所有现有的回归测试

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author